### PR TITLE
fixed typo: rcm -> rvm

### DIFF
--- a/mac
+++ b/mac
@@ -117,7 +117,6 @@ tap "caskroom/cask"
 # Unix
 brew "git"
 brew "openssl"
-brew "rvm"
 brew "reattach-to-user-namespace"
 brew "the_silver_searcher"
 brew "tmux"

--- a/mac
+++ b/mac
@@ -117,7 +117,7 @@ tap "caskroom/cask"
 # Unix
 brew "git"
 brew "openssl"
-brew "rcm"
+brew "rvm"
 brew "reattach-to-user-namespace"
 brew "the_silver_searcher"
 brew "tmux"


### PR DESCRIPTION
fixed typo: rcm -> rvm